### PR TITLE
FIX: ExcelReader

### DIFF
--- a/pyetl/reader.py
+++ b/pyetl/reader.py
@@ -115,7 +115,16 @@ class ExcelReader(Reader):
             self.detect_table_border()
 
     def get_dataset(self, columns):
-        df = self.df.where(self.df.notnull(), None).rename(columns=columns)
+        df = self.df.where(self.df.notnull(), None)
+        df=df.reset_index() 
+
+        ss=[s for s, t in columns.items() if s in list(df)]
+        tt=[t for s, t in columns.items() if s in list(df)]
+        df = df.loc[:,ss]
+
+        df.columns=tt
+        df=df.fillna(value='')
+        df=df.astype(str)
         return Dataset(df.to_dict("records"))
 
     @property


### PR DESCRIPTION
你好 我最近用这个在实际工作中处理数据, 从十几种不同来源和格式的excel导入 到Oracle数据库中, 用了您的这个, 还挺好用的, 遇到了些实际问题, 自己做了很多调试, 临时解决了下. 供参考:

1. when rename-to column exists,would be dup and use the last one
比如有个excel, 原列为"品名,包装2,包装", 取"品名,包装2"列对应入数据库为"品名,包装" ,
此时rename包装2列为包装, df内列重复为"品名,包装,包装", 结果to_dict时实际取到的是原列的"品名,包装"
换了下重命名的方式令其不会重复.

2. add index to the dict for further use in order-awared occasion
原始行号index列保留在dict中, 这样如果需要行号可以直接在columns中取.
用function我不知道怎么构建这个...

3. all value as str, prevent inserting error: diffrent type some line
4. all None as Empty
插入cxOracle的时候, 如果不同行的数据类型稍有不同, 比如第一行的值可能被认为是文本,第二行又是数字, 
cursor.executemany(statement, parameters)时会报TypeError: expecting string or bytes object
处理成文本可以解决这个, 但副作用是形成None字符串, 事先把null弄成空串来解.